### PR TITLE
Refactor item scripts

### DIFF
--- a/js/item.js
+++ b/js/item.js
@@ -801,6 +801,92 @@ const precioVentaUnidadMercado = (mainNode && typeof mainNode.sell_price === 'nu
     }
     return null;
   }
+
+  // --- Lógica de negocio compartida con item-ui.js ---
+  function setIngredientObjs(val) {
+    window.ingredientObjs = val;
+  }
+
+  function setGlobalQty(val) {
+    window.globalQty = val;
+  }
+
+  function snapshotExpandState(ings) {
+    if (!ings) return [];
+    return ings.map(ing => ({
+      id: ing.id,
+      expanded: ing.expanded,
+      children: snapshotExpandState(ing.children || [])
+    }));
+  }
+
+  function restoreExpandState(ings, snapshot) {
+    if (!ings || !snapshot) return;
+    for (let i = 0; i < ings.length; i++) {
+      if (snapshot[i]) {
+        ings[i].expanded = snapshot[i].expanded;
+        restoreExpandState(ings[i].children, snapshot[i].children);
+      }
+    }
+  }
+
+  function recalcAll(ingredientObjs, globalQty) {
+    if (!ingredientObjs) return;
+    ingredientObjs.forEach((ing, idx) => {
+      if (idx === 0) {
+        ing.recalc(globalQty, null, null, true);
+      } else {
+        ing.recalc(globalQty);
+      }
+    });
+  }
+
+  function getTotals(ingredientObjs) {
+    let totalBuy = 0, totalSell = 0, totalCrafted = 0;
+    for (const ing of ingredientObjs) {
+      totalBuy += ing.total_buy || 0;
+      totalSell += ing.total_sell || 0;
+      totalCrafted += ing.total_crafted || 0;
+    }
+    return { totalBuy, totalSell, totalCrafted };
+  }
+
+  function findIngredientByIdAndParent(ings, id, parentId) {
+    for (const ing of ings) {
+      if (String(ing.id) === String(id) && String(ing._parentId) === String(parentId)) {
+        return ing;
+      }
+      if (Array.isArray(ing.children) && ing.children.length) {
+        const found = findIngredientByIdAndParent(ing.children, id, parentId);
+        if (found) return found;
+      }
+    }
+    return null;
+  }
+
+  function findIngredientByPath(ings, pathArr) {
+    let current = ings;
+    let ing = null;
+    for (let i = 0; i < pathArr.length; i++) {
+      const uid = pathArr[i];
+      ing = (current || []).find(n => String(n._uid) === String(uid));
+      if (!ing) return null;
+      current = ing.children;
+    }
+    return ing;
+  }
+
+  // Exponer funciones para item-ui.js
+  window.setIngredientObjs = setIngredientObjs;
+  window.setGlobalQty = setGlobalQty;
+  window.snapshotExpandState = snapshotExpandState;
+  window.restoreExpandState = restoreExpandState;
+  window.recalcAll = recalcAll;
+  window.getTotals = getTotals;
+  window.findIngredientByIdAndParent = findIngredientByIdAndParent;
+  window.findIngredientByPath = findIngredientByPath;
+  window.findIngredientByUid = findIngredientByUid;
+  window.findIngredientById = findIngredientById;
   
   
   


### PR DESCRIPTION
## Summary
- move business helpers from `item-ui.js` into `item.js`
- expose business functions globally for the UI script
- keep `item-ui.js` focused on rendering only

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_686c13ea23fc8328a401f9a0e2e28a3b