### PR TITLE
Use global recipe loader

### DIFF
--- a/js/services/recipeService.js
+++ b/js/services/recipeService.js
@@ -13,7 +13,7 @@ const cache = {
  * @param {number} itemId - ID del ítem
  * @returns {Promise<Array>} - Lista de recetas
  */
-window.getRecipesForItem = async function(itemId) {
+async function getRecipesForItem(itemId) {
     if (!itemId) {
         console.error('[ERROR] ID de ítem no proporcionado');
         return [];
@@ -48,6 +48,8 @@ window.getRecipesForItem = async function(itemId) {
         return [];
     }
 }
+
+window.getRecipesForItem = getRecipesForItem;
 
 /**
  * Obtiene los detalles de una receta específica
@@ -135,3 +137,8 @@ window.getItemPrices = async function(itemId) {
         return { buys: { unit_price: 0 }, sells: { unit_price: 0 } };
     }
 };
+
+// Export para entornos que soporten CommonJS
+if (typeof module !== 'undefined' && module.exports) {
+    module.exports.getRecipesForItem = getRecipesForItem;
+}

--- a/js/utils/recipeUtils.js
+++ b/js/utils/recipeUtils.js
@@ -1,22 +1,7 @@
 // Dependencias: estas funciones deben estar definidas globalmente antes de este archivo
-// getRecipeDetails, getItemDetails, getItemPrices
+// getRecipesForItem, getRecipeDetails, getItemDetails, getItemPrices
 
-// Integración robusta: función local para obtener recetas, inspirada en SOLO-REFERENCIA
-async function getRecipesForItem(itemId) {
-    const API_BASE_URL = 'https://api.guildwars2.com/v2';
-    if (!window._recipeCache) window._recipeCache = {};
-    if (window._recipeCache[itemId]) return window._recipeCache[itemId];
-    try {
-        const response = await fetch(`${API_BASE_URL}/recipes/search?output=${itemId}`);
-        if (!response.ok) throw new Error('Error al buscar recetas');
-        const recipeIds = await response.json();
-        window._recipeCache[itemId] = recipeIds;
-        return recipeIds;
-    } catch (error) {
-        console.error('Error en getRecipesForItem:', error);
-        return [];
-    }
-}
+// Se asume que getRecipesForItem está definido globalmente en recipeService.js
 
 
 /**


### PR DESCRIPTION
## Summary
- export `getRecipesForItem` from recipeService
- rely on the global `getRecipesForItem` in recipeUtils

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c549a57808328acc6044ffb606aae