### PR TITLE
Refactor toast styles

### DIFF
--- a/css/global-gw.css
+++ b/css/global-gw.css
@@ -2331,3 +2331,32 @@ p .info-text{
 }
 
   
+/* Toast notifications */
+#toast-container {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 1000;
+}
+
+.toast {
+  padding: 12px 24px;
+  margin-bottom: 10px;
+  border-radius: 4px;
+  color: #fff;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.2);
+  opacity: 0;
+  transition: opacity 0.3s;
+}
+
+.toast-success {
+  background: #4CAF50;
+}
+
+.toast-error {
+  background: #ff4444;
+}
+
+.toast-info {
+  background: #2196F3;
+}

--- a/js/storageUtils.js
+++ b/js/storageUtils.js
@@ -67,24 +67,14 @@ function showToast(message, type = 'success') {
     if (!container) {
         container = document.createElement('div');
         container.id = 'toast-container';
-        container.style.position = 'fixed';
-        container.style.bottom = '20px';
-        container.style.right = '20px';
-        container.style.zIndex = '1000';
+        container.className = 'toast-container';
         document.body.appendChild(container);
     }
-    
+
     // Crear toast
     const toast = document.createElement('div');
     toast.className = `toast toast-${type}`;
-    toast.style.padding = '12px 24px';
-    toast.style.marginBottom = '10px';
-    toast.style.borderRadius = '4px';
-    toast.style.background = type === 'error' ? '#ff4444' : '#4CAF50';
-    toast.style.color = 'white';
-    toast.style.boxShadow = '0 2px 10px rgba(0,0,0,0.2)';
     toast.style.opacity = '0';
-    toast.style.transition = 'opacity 0.3s';
     toast.textContent = message;
     
     // Agregar al DOM


### PR DESCRIPTION
## Summary
- style toast messages with CSS instead of inline styles
- update `showToast` to use new classes

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686c5afbc6508328b3551c62bcd01d91