### PR TITLE
Consolidate fractal stack datasets

### DIFF
--- a/js/fractales-gold-logic.js
+++ b/js/fractales-gold-logic.js
@@ -14,6 +14,68 @@ export const FRACTALES_ITEMS = [
   { key: 'escama', id: 24288, nombre: 'Escama grande' },
   { key: 'infusion_mas1', id: 49424, nombre: 'Infusión +1' }
 ];
+
+// Datos de stacks de fractales obtenidos de registros históricos
+// Se utilizan para calcular promedios de materiales y oro
+export const FRACTAL_STACKS = [
+  {
+    stacks: 55,
+    data: {
+      oro_de_basura: 59510000,
+      garra: 4625.45,
+      totem: 4360.23,
+      sangre: 5005.12,
+      veneno: 4610.56,
+      hueso: 4685.78,
+      escama: 4750.98,
+      colmillo: 4845.01,
+      polvo: 4855.34,
+      infusion_mas1: 31039.56,
+      llaves_encriptacion: 1426.12,
+      empíreos: 8445.67
+    }
+  },
+  {
+    stacks: 17,
+    data: {
+      oro_de_basura: 18068500,
+      garra: 1340.23,
+      totem: 1640.45,
+      sangre: 1385.12,
+      veneno: 1475.56,
+      hueso: 1380.78,
+      escama: 1585.98,
+      colmillo: 1295.01,
+      polvo: 1540.34,
+      infusion_mas1: 9799.56,
+      llaves_encriptacion: 427.12,
+      empíreos: 4125.67
+    }
+  },
+  {
+    stacks: 32,
+    data: {
+      oro_de_basura: 34443500,
+      recetas_ascendentes: 65.23,
+      infusion_mas1: 18256.56,
+      llaves_encriptacion: 783.12,
+      hueso: 2685.78,
+      veneno: 2775.98,
+      polvo: 2665.34,
+      totem: 2815.01,
+      garra: 2730.45,
+      colmillo: 2685.12,
+      sangre: 2545.56,
+      escama: 2645.98,
+      hematites: 8090.12,
+      empíreos: 7645.67,
+      dragonita: 7645.67,
+      sacos_reliquias: 538.12,
+      saco_equipamiento: 4.01,
+      miniatura: 154
+    }
+  }
+];
 // Ítems no comerciables o no relevantes para fractales (comentados)
 // { key: 'infusion_mas1', id: 49424, nombre: 'Infusión +1' },
 // { key: 'empireos', id: 77302, nombre: 'Fragmento de empíreo' },

--- a/js/fractales-gold-ui.js
+++ b/js/fractales-gold-ui.js
@@ -11,26 +11,11 @@ export function setValoresFractales({ compra75919, venta75919, compra73248, vent
   valorCompra73248 = compra73248;
   valorVenta73248 = venta73248;
 }
-import { FRACTALES_ITEMS, getItemsConMercado, keyToNombre } from './fractales-gold-logic.js';
+import { FRACTALES_ITEMS, FRACTAL_STACKS, getItemsConMercado, keyToNombre } from './fractales-gold-logic.js';
 
 // --- Renderiza la tabla de promedios por stack ---
 export async function renderTablaPromedios(containerId = 'tabla-promedios') {
-  const sets = [
-    { stacks: 55, data: {
-      oro_de_basura: 59510000,
-      garra: 4625.45, totem: 4360.23, sangre: 5005.12, veneno: 4610.56, hueso: 4685.78, escama: 4750.98, colmillo: 4845.01, polvo: 4855.34, infusion_mas1: 31039.56,
-      llaves_encriptacion: 1426.12, empíreos: 8445.67
-    } },
-    { stacks: 17, data: {
-      oro_de_basura: 18068500,
-      garra: 1340.23, totem: 1640.45, sangre: 1385.12, veneno: 1475.56, hueso: 1380.78, escama: 1585.98, colmillo: 1295.01, polvo: 1540.34, infusion_mas1: 9799.56,
-      llaves_encriptacion: 427.12, empíreos: 4125.67
-    } },
-    { stacks: 32, data: {
-      oro_de_basura: 34443500,
-      recetas_ascendentes: 65.23, infusion_mas1: 18256.56, llaves_encriptacion: 783.12, hueso: 2685.78, veneno: 2775.98, polvo: 2665.34, totem: 2815.01, garra: 2730.45, colmillo: 2685.12, sangre: 2545.56, escama: 2645.98, hematites: 8090.12, empíreos: 7645.67, dragonita: 7645.67, sacos_reliquias: 538.12, saco_equipamiento: 4.01, miniatura: 154
-    } }
-  ];
+  const sets = FRACTAL_STACKS;
   const claves = [
     { key: 'oro_de_basura', nombre: 'Oro crudo' },
     { key: 'garra', nombre: 'Garra potente' },
@@ -100,11 +85,7 @@ export async function renderTablaPrecios(containerId = 'tabla-precios-fractales'
     if (infusion) itemsMostrar.push(infusion);
   }
   // Calcular promedios ponderados por material (igual que en renderTablaPromedios)
-  const sets = [
-    { stacks: 55, data: { oro_de_basura: 59510000, garra: 4625, totem: 4360, sangre: 5005, veneno: 4610, hueso: 4685, escama: 4750, colmillo: 4845, polvo: 4855, infusion_mas1: 31039 } },
-    { stacks: 17, data: { oro_de_basura: 18068500, garra: 1340, totem: 1640, sangre: 1385, veneno: 1475, hueso: 1380, escama: 1585, colmillo: 1295, polvo: 1540, infusion_mas1: 9799 } },
-    { stacks: 32, data: { oro_de_basura: 34443500, infusion_mas1: 18256, hueso: 2685, veneno: 2775, polvo: 2665, totem: 2815, garra: 2730, colmillo: 2685, sangre: 2545, escama: 2645 } }
-  ];
+  const sets = FRACTAL_STACKS;
   const promedios = {};
   itemsMostrar.forEach(item => {
     let suma = 0, sumaStacks = 0, apariciones = 0;
@@ -174,11 +155,7 @@ export async function renderTablaPrecios(containerId = 'tabla-precios-fractales'
 // --- Renderiza la tabla resumen de oro crudo + materiales × 0.85 ---
 export async function renderTablaResumenOro(containerId = 'tabla-resumen-oro') {
   // 1. Promedio de oro crudo
-  const sets = [
-    { stacks: 55, data: { oro_de_basura: 59510000 } },
-    { stacks: 17, data: { oro_de_basura: 18068500 } },
-    { stacks: 32, data: { oro_de_basura: 34443500 } }
-  ];
+  const sets = FRACTAL_STACKS;
   let suma = 0, sumaStacks = 0;
   sets.forEach(set => {
     if (set.data["oro_de_basura"] !== undefined) {
@@ -214,28 +191,7 @@ export async function renderTablaResumenOro(containerId = 'tabla-resumen-oro') {
   }));
 
   // 3. Promedios por material (solo los comerciables)
-  const setsPromedios = [
-    {
-      stacks: 55,
-      data: {
-        garra: 4625, totem: 4360, sangre: 5005, veneno: 4610, hueso: 4685, escama: 4750, colmillo: 4845, polvo: 4855,
-        infusion_mas1: 31039
-      }
-    },
-    {
-      stacks: 17,
-      data: {
-        garra: 1340, totem: 1640, sangre: 1385, veneno: 1475, hueso: 1380, escama: 1585, colmillo: 1295, polvo: 1540,
-        infusion_mas1: 9799
-      }
-    },
-    {
-      stacks: 32,
-      data: {
-        infusion_mas1: 18256, hueso: 2685, veneno: 2775, polvo: 2665, totem: 2815, garra: 2730, colmillo: 2685, sangre: 2545, escama: 2645
-      }
-    }
-  ];
+  const setsPromedios = FRACTAL_STACKS;
   const promedios = {};
   precios.forEach(item => {
     let suma = 0, sumaStacks = 0, apariciones = 0;


### PR DESCRIPTION
## Summary
- centralize data for fractal stacks in new `FRACTAL_STACKS` constant
- compute averages for fractal tables from the centralized constant

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c72a45dc483289db86eea55119691