### PR TITLE
Lazy load legendary crafting modules

### DIFF
--- a/js/leg-craft-tabs.js
+++ b/js/leg-craft-tabs.js
@@ -1,0 +1,44 @@
+// js/leg-craft-tabs.js
+// Handles tab switching and lazy loading of legendary crafting modules
+
+const loaded = {
+  first: false,
+  third: false
+};
+
+async function loadFirstGen() {
+  if (loaded.first) return;
+  loaded.first = true;
+  await import('./legendaryCrafting1gen.js');
+}
+
+async function loadThirdGen() {
+  if (loaded.third) return;
+  loaded.third = true;
+  await import('./legendaryCrafting3gen.js');
+}
+
+function switchTab(tabId) {
+  document.querySelectorAll('.container-first, .container-third').forEach(tab => {
+    tab.style.display = 'none';
+  });
+  document.querySelectorAll('.item-tab-btn').forEach(btn => btn.classList.remove('active'));
+
+  const target = document.getElementById(tabId);
+  const button = document.querySelector(`.item-tab-btn[data-tab="${tabId}"]`);
+  if (target) target.style.display = 'block';
+  if (button) button.classList.add('active');
+
+  if (tabId === 'tab-first-gen') loadFirstGen();
+  else if (tabId === 'tab-third-gen') loadThirdGen();
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const tabButtons = document.querySelectorAll('.item-tab-btn');
+  tabButtons.forEach(btn => {
+    btn.addEventListener('click', () => {
+      const tabId = btn.getAttribute('data-tab');
+      switchTab(tabId);
+    });
+  });
+});

--- a/js/legendaryCrafting1gen.js
+++ b/js/legendaryCrafting1gen.js
@@ -24,18 +24,16 @@ const quickLoadButtons = {
   btnFrenesi: { id: 'btnFrenesi', itemId: '30697', itemName: 'Frenesí' }
 };
 
-document.addEventListener('DOMContentLoaded', () => {
-  window.appFirstGen = new LegendaryCraftingBase({
-    getItemById: id => getLegendaryItem(parseInt(id)),
-    items: Object.values(LEGENDARY_ITEMS),
-    createIngredientTree,
-    isBasicMaterial,
-    quickLoadButtons,
-    elementIds: {
-      craftingTree: 'craftingTree',
-      summary: 'summary',
-      summaryContent: 'summaryContent',
-      clearCache: 'clearCache'
-    }
-  });
+window.appFirstGen = new LegendaryCraftingBase({
+  getItemById: id => getLegendaryItem(parseInt(id)),
+  items: Object.values(LEGENDARY_ITEMS),
+  createIngredientTree,
+  isBasicMaterial,
+  quickLoadButtons,
+  elementIds: {
+    craftingTree: 'craftingTree',
+    summary: 'summary',
+    summaryContent: 'summaryContent',
+    clearCache: 'clearCache'
+  }
 });

--- a/js/legendaryCrafting3gen.js
+++ b/js/legendaryCrafting3gen.js
@@ -21,21 +21,19 @@ const quickLoadButtons = {
   btnReflexion: { id: 'btnReflexion', itemId: '96652', itemName: 'Reflexión de Aurene' }
 };
 
-document.addEventListener('DOMContentLoaded', () => {
-  window.appThirdGen = new LegendaryCraftingBase({
-    getItemById: id => getLegendary3GenItem(parseInt(id)),
-    items: Object.values(LEGENDARY_ITEMS_3GEN),
-    createIngredientTree,
-    isBasicMaterial: isBasic3GenMaterial,
-    quickLoadButtons,
-    elementIds: {
-      craftingTree: 'craftingTreeThird',
-      summary: 'summaryThird',
-      summaryContent: 'summaryContentThird',
-      loadTree: 'loadTreeThird',
-      clearCache: 'clearCacheThird',
-      itemIdInput: 'itemIdThird',
-      itemNameInput: 'itemNameThird'
-    }
-  });
+window.appThirdGen = new LegendaryCraftingBase({
+  getItemById: id => getLegendary3GenItem(parseInt(id)),
+  items: Object.values(LEGENDARY_ITEMS_3GEN),
+  createIngredientTree,
+  isBasicMaterial: isBasic3GenMaterial,
+  quickLoadButtons,
+  elementIds: {
+    craftingTree: 'craftingTreeThird',
+    summary: 'summaryThird',
+    summaryContent: 'summaryContentThird',
+    loadTree: 'loadTreeThird',
+    clearCache: 'clearCacheThird',
+    itemIdInput: 'itemIdThird',
+    itemNameInput: 'itemNameThird'
+  }
 });

--- a/leg-craft.html
+++ b/leg-craft.html
@@ -133,30 +133,9 @@
   </div>
 
   <script src="js/formatGold.js"></script>
-  <script type="module" src="js/legendaryCrafting3gen.js"></script>
-  <script type="module" src="js/legendaryCrafting1gen.js"></script>
   <script src="js/auth.js"></script>
   <script src="js/navigation.js"></script>
-  <script>
-    // Tabs functionality
-    document.addEventListener('DOMContentLoaded', function() {
-      const tabBtns = document.querySelectorAll('.item-tab-btn');
-      tabBtns.forEach(btn => {
-        btn.addEventListener('click', function() {
-          // Remove active class from all buttons and hide all tabs
-          tabBtns.forEach(b => b.classList.remove('active'));
-          document.querySelectorAll('.container-first, .container-third').forEach(tab => {
-            tab.style.display = 'none';
-          });
-          
-          // Add active class to clicked button and show corresponding tab
-          btn.classList.add('active');
-          const tabId = btn.getAttribute('data-tab');
-          document.getElementById(tabId).style.display = 'block';
-        });
-      });
-    });
-  </script>
+  <script type="module" src="js/leg-craft-tabs.js"></script>
   
 </body>
 </html>


### PR DESCRIPTION
## Summary
- load legendary crafting modules on demand
- use new `leg-craft-tabs.js` to handle tabs and dynamic imports

## Testing
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686c7eee522083288f29b859db46cce1