### PR TITLE
Refactor search modal helpers

### DIFF
--- a/compare-craft.html
+++ b/compare-craft.html
@@ -92,27 +92,20 @@
       <div id="modal-results" class="item-list"></div>
     </div>
   </div>
+  <script src="js/modal-utils.js"></script>
   <script>
-  // Modal open/close logic (idéntico a index.html)
   document.addEventListener('DOMContentLoaded', function() {
     const openBtn = document.getElementById('open-search-modal');
     const modal = document.getElementById('search-modal');
     const closeBtn = document.getElementById('close-search-modal');
     openBtn.addEventListener('click', function(e) {
       e.preventDefault();
-      modal.style.display = 'block';
-      // El script js/search-modal-compare-craft.js ya está cargado de forma estática al final del HTML
+      openSearchModal('js/search-modal-compare-craft.js');
     });
-    closeBtn.addEventListener('click', function() {
-      modal.style.display = 'none';
-    });
-    // Cierra modal con fondo
-    modal.querySelector('.search-modal-backdrop').addEventListener('click', function() {
-      modal.style.display = 'none';
-    });
-    // Escape para cerrar
+    closeBtn.addEventListener('click', closeSearchModal);
+    modal.querySelector('.search-modal-backdrop').addEventListener('click', closeSearchModal);
     document.addEventListener('keydown', function(e) {
-      if (e.key === 'Escape') modal.style.display = 'none';
+      if (e.key === 'Escape') closeSearchModal();
     });
   });
   </script>
@@ -153,7 +146,6 @@
 <script src="js/auth.js"></script>
 <script src="js/navigation.js"></script>
 <script src="js/storageUtils.js"></script>
-<script src="js/search-modal-compare-craft.js"></script>
 <!-- Manejadores de comparativa (guardar comparativa) -->
 <script src="js/compareHandlers.js"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -68,45 +68,20 @@
           <div id="modal-results" class="item-list"></div>
         </div>
       </div>
+      <script src="js/modal-utils.js"></script>
       <script>
-      // Modal open/close logic
       document.addEventListener('DOMContentLoaded', function() {
         const openBtn = document.getElementById('open-search-modal');
         const modal = document.getElementById('search-modal');
         const closeBtn = document.getElementById('close-search-modal');
         openBtn.addEventListener('click', function(e) {
           e.preventDefault();
-          modal.style.display = 'block';
-          // Lazy load script only once
-          if (!window._searchLoaded) {
-            // Cargar primero js/formatGold.js si no está presente
-            if (!window.formatGold) {
-              const goldScript = document.createElement('script');
-              goldScript.src = 'js/formatGold.js';
-              document.body.appendChild(goldScript);
-              goldScript.onload = function() {
-                const script = document.createElement('script');
-                script.src = 'js/search-modal.js';
-                document.body.appendChild(script);
-              };
-            } else {
-              const script = document.createElement('script');
-              script.src = 'js/search-modal.js';
-              document.body.appendChild(script);
-            }
-            window._searchLoaded = true;
-          }
+          openSearchModal();
         });
-        closeBtn.addEventListener('click', function() {
-          modal.style.display = 'none';
-        });
-        // Cierra modal con fondo
-        modal.querySelector('.search-modal-backdrop').addEventListener('click', function() {
-          modal.style.display = 'none';
-        });
-        // Escape para cerrar
+        closeBtn.addEventListener('click', closeSearchModal);
+        modal.querySelector('.search-modal-backdrop').addEventListener('click', closeSearchModal);
         document.addEventListener('keydown', function(e) {
-          if (e.key === 'Escape') modal.style.display = 'none';
+          if (e.key === 'Escape') closeSearchModal();
         });
       });
       </script>

--- a/item.html
+++ b/item.html
@@ -91,45 +91,20 @@
       <div id="modal-results" class="item-list"></div>
     </div>
   </div>
+  <script src="js/modal-utils.js"></script>
   <script>
-  // Modal open/close logic (idéntico a index.html)
   document.addEventListener('DOMContentLoaded', function() {
     const openBtn = document.getElementById('open-search-modal');
     const modal = document.getElementById('search-modal');
     const closeBtn = document.getElementById('close-search-modal');
     openBtn.addEventListener('click', function(e) {
       e.preventDefault();
-      modal.style.display = 'block';
-      // Lazy load script only once
-      if (!window._searchLoaded) {
-        // Cargar primero js/formatGold.js si no está presente
-        if (!window.formatGold) {
-          const goldScript = document.createElement('script');
-          goldScript.src = 'js/formatGold.js';
-          document.body.appendChild(goldScript);
-          goldScript.onload = function() {
-            const script = document.createElement('script');
-            script.src = 'js/search-modal.js';
-            document.body.appendChild(script);
-          };
-        } else {
-          const script = document.createElement('script');
-          script.src = 'js/search-modal.js';
-          document.body.appendChild(script);
-        }
-        window._searchLoaded = true;
-      }
+      openSearchModal();
     });
-    closeBtn.addEventListener('click', function() {
-      modal.style.display = 'none';
-    });
-    // Cierra modal con fondo
-    modal.querySelector('.search-modal-backdrop').addEventListener('click', function() {
-      modal.style.display = 'none';
-    });
-    // Escape para cerrar
+    closeBtn.addEventListener('click', closeSearchModal);
+    modal.querySelector('.search-modal-backdrop').addEventListener('click', closeSearchModal);
     document.addEventListener('keydown', function(e) {
-      if (e.key === 'Escape') modal.style.display = 'none';
+      if (e.key === 'Escape') closeSearchModal();
     });
   });
   </script>

--- a/js/modal-utils.js
+++ b/js/modal-utils.js
@@ -1,0 +1,33 @@
+(function() {
+  function loadScript(url) {
+    var script = document.createElement('script');
+    script.src = url;
+    document.body.appendChild(script);
+  }
+
+  window.openSearchModal = function(scriptUrl = 'js/search-modal.js') {
+    var modal = document.getElementById('search-modal');
+    if (!modal) return;
+    modal.style.display = 'block';
+    if (!window._searchLoaded && scriptUrl !== null) {
+      var loadMain = function() {
+        if (scriptUrl) loadScript(scriptUrl);
+      };
+      if (!window.formatGold) {
+        var goldScript = document.createElement('script');
+        goldScript.src = 'js/formatGold.js';
+        document.body.appendChild(goldScript);
+        goldScript.onload = loadMain;
+      } else {
+        loadMain();
+      }
+      window._searchLoaded = true;
+    }
+  };
+
+  window.closeSearchModal = function() {
+    var modal = document.getElementById('search-modal');
+    if (!modal) return;
+    modal.style.display = 'none';
+  };
+})();


### PR DESCRIPTION
## Summary
- centralize open/close search modal logic in `modal-utils.js`
- load `modal-utils.js` and use its functions from `index.html`, `item.html` and `compare-craft.html`
- lazily load proper modal script on demand for `compare-craft.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c82fb17248328936535da52f88394