### PR TITLE
Fix initial load for legendary crafting tabs

### DIFF
--- a/js/leg-craft-tabs.js
+++ b/js/leg-craft-tabs.js
@@ -41,4 +41,11 @@ document.addEventListener('DOMContentLoaded', () => {
       switchTab(tabId);
     });
   });
+
+  // Load script for the tab that is active on initial page load
+  const defaultBtn = document.querySelector('.item-tab-btn.active');
+  if (defaultBtn) {
+    const tabId = defaultBtn.getAttribute('data-tab');
+    switchTab(tabId);
+  }
 });


### PR DESCRIPTION
## Summary
- ensure the first generation module loads when the page opens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686c7952c6ac8328a928cbde16d54409