### PR TITLE
Improve abrir vs vender chart

### DIFF
--- a/fractales-gold.html
+++ b/fractales-gold.html
@@ -6,6 +6,7 @@
   <link rel="icon" href="/img/favicon.ico" sizes="16x16" type="image/x-icon">
   <title>Promedios Fractales - GW2</title>
   <link rel="stylesheet" href="css/global-gw.css">
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
   <header>
@@ -50,6 +51,12 @@
         </div>
         <div class="card" style="margin-top:32px;">
           <div style="text-align: center;margin-bottom: 25px;">
+            <h2>Contribución de oro por material</h2>
+          </div>
+          <canvas id="contribuciones-chart" height="120"></canvas>
+        </div>
+        <div class="card" style="margin-top:32px;">
+          <div style="text-align: center;margin-bottom: 25px;">
           <h2>Referencias para profit</h2>
           <p>Valores de referencia para comparar el profit</p>
           </div>
@@ -57,6 +64,12 @@
           <div id="tabla-referencias-profit"></div>
           <p>NOTA: Las matrices estabilizadoras fungen el papel de llaves, ya que se puede cambiar por llaves con el NPC de fractales. Y así obtener un valor por llave.
           Y se toma como referencia para asignarle un valor a las llaves de encriptación. </p>
+        </div>
+        <div class="card" style="margin-top:32px;">
+          <div style="text-align: center;margin-bottom: 25px;">
+            <h2>Abrir vs Vender Encriptaciones</h2>
+          </div>
+          <canvas id="abrir-vs-vender-chart" height="120"></canvas>
         </div>
       </div>
     </main>
@@ -77,7 +90,7 @@
     });
   </script>
   <script type="module">
-    import { renderTablaPrecios, renderTablaPromedios, renderTablaResumenOro, renderTablaReferenciasProfit, fetchItemPrices } from './js/fractales-gold-ui.js';
+    import { renderGraficoContribuciones, renderGraficoAbrirVsVender, renderTablaPrecios, renderTablaPromedios, renderTablaResumenOro, renderTablaReferenciasProfit, fetchItemPrices } from './js/fractales-gold-ui.js';
 
     async function fetchPreciosFractales() {
       const priceMap = await fetchItemPrices([75919, 73248]);
@@ -89,12 +102,15 @@
       };
     }
 
+
     async function renderTodo() {
       const preciosFractales = await fetchPreciosFractales();
       await renderTablaPromedios();
       await renderTablaPrecios();
-      await renderTablaResumenOro('tabla-resumen-oro', preciosFractales);
-      renderTablaReferenciasProfit('tabla-referencias-profit', preciosFractales);
+      const resumenData = await renderTablaResumenOro('tabla-resumen-oro', preciosFractales);
+      renderGraficoContribuciones(resumenData.contribuciones);
+      renderTablaReferenciasProfit('tabla-referencias-profit', preciosFractales, resumenData);
+      renderGraficoAbrirVsVender('abrir-vs-vender-chart', preciosFractales, resumenData);
     }
 
     renderTodo();

--- a/js/fractales-gold-ui.js
+++ b/js/fractales-gold-ui.js
@@ -13,6 +13,8 @@ export function setValoresFractales({ compra75919, venta75919, compra73248, vent
 }
 import { FRACTALES_ITEMS, FRACTAL_STACKS, getItemsConMercado, keyToNombre } from './fractales-gold-logic.js';
 
+let contribucionesChart = null;
+let abrirVenderChart = null;
 // --- Helper para obtener precios de múltiples ítems en una sola llamada ---
 export async function fetchItemPrices(ids = []) {
   if (!ids || ids.length === 0) return {};
@@ -244,14 +246,14 @@ export async function renderTablaResumenOro(containerId = 'tabla-resumen-oro', p
   // 5. Aplicar 0.85 y sumar oro crudo
     const sumaCompra = promedioOro + (totalCompra * 0.85);
     const sumaVenta = promedioOro + (totalVenta * 0.85);
+    const contribuciones = [{ nombre: "Oro crudo", valor: promedioOro }];
+    precios.forEach(item => {
+      const promedio = promedios[item.key];
+      if (promedio !== undefined) {
+        contribuciones.push({ nombre: keyToNombre(item.key), valor: item.sell_price * promedio * 0.85 });
+      }
+    });
 
-  // 6. Precios de encriptaciones (se pasan desde fuera)
-    const {
-      compra75919 = 0,
-      venta75919 = 0,
-      compra73248 = 0,
-      venta73248 = 0
-    } = preciosFractales;
 
   // 7. Render tabla
     const htmlResumen = `
@@ -275,18 +277,24 @@ export async function renderTablaResumenOro(containerId = 'tabla-resumen-oro', p
     </table>
   `;
     document.getElementById(containerId).innerHTML = htmlResumen;
+    return { sumaCompra, sumaVenta, contribuciones };
   } catch (err) {
     console.error('Error en renderTablaResumenOro:', err);
   }
 }
 
-export function renderTablaReferenciasProfit(containerId = 'tabla-referencias-profit', preciosFractales = {}) {
+
+
+export function renderTablaReferenciasProfit(containerId = 'tabla-referencias-profit', preciosFractales = {}, resumen = {}) {
   const {
     compra75919 = 0,
     venta75919 = 0,
     compra73248 = 0,
     venta73248 = 0
   } = preciosFractales;
+  const { sumaVenta = 0 } = resumen;
+  const costoAbrir = (compra75919 + compra73248) * 250;
+  const roi = costoAbrir > 0 ? ((sumaVenta - costoAbrir) / costoAbrir) * 100 : 0;
   const htmlFractales = `
     <table class="table-modern" style="margin-top:0;">
       <thead>
@@ -320,9 +328,91 @@ export function renderTablaReferenciasProfit(containerId = 'tabla-referencias-pr
           <td><div class="dato-item">Suma Encriptación + Matriz (venta) - 15% de comisión</div></td>
           <td><div class="dato-item-info">${window.formatGold(((venta75919 + venta73248) * 250) * 0.85)}</div></td>
         </tr>
+        <tr>
+          <td><div class="dato-item"><strong>ROI abrir stack</strong></div></td>
+          <td><div class="dato-item-info" style="color:${roi>=0 ? 'green' : 'red'};">${roi.toFixed(2)} %</div></td>
+        </tr>
       </tbody>
     </table>
   `;
   document.getElementById(containerId).innerHTML = htmlFractales;
 }
 
+export function renderGraficoContribuciones(contribuciones = [], containerId = 'contribuciones-chart') {
+  const ctx = document.getElementById(containerId)?.getContext('2d');
+  if (!ctx) return;
+  if (contribucionesChart) contribucionesChart.destroy();
+  const labels = contribuciones.map(c => c.nombre);
+  const data = contribuciones.map(c => c.valor / 10000);
+  contribucionesChart = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels,
+      datasets: [{
+        label: 'Oro',
+        data,
+        backgroundColor: 'rgba(54, 162, 235, 0.6)'
+      }]
+    },
+    options: {
+      responsive: true,
+      plugins: { legend: { display: false } },
+      scales: { y: { beginAtZero: true, title: { display: true, text: 'Oro' } } }
+    }
+  });
+}
+
+export function renderGraficoAbrirVsVender(containerId = 'abrir-vs-vender-chart', preciosFractales = {}, resumen = {}) {
+  const ctx = document.getElementById(containerId)?.getContext('2d');
+  if (!ctx) return;
+  if (abrirVenderChart) abrirVenderChart.destroy();
+
+  const {
+    venta75919 = 0,
+    compra75919 = 0,
+    compra73248 = 0
+  } = preciosFractales;
+  const { sumaVenta = 0 } = resumen;
+
+  const venderStack = venta75919 * 250 * 0.85;
+  const abrirConLlaves = sumaVenta;
+  const abrirComprandoMatrices = abrirConLlaves - (compra73248 * 250);
+  const abrirComprandoAmbos = abrirConLlaves - ((compra75919 + compra73248) * 250);
+
+  abrirVenderChart = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: [
+        'Vender stack de encriptación',
+        'Abrir con llaves',
+        'Abrir comprando matrices',
+        'Abrir comprando matrices y encriptaciones'
+      ],
+      datasets: [{
+        label: 'Oro',
+        data: [
+          venderStack / 10000,
+          abrirConLlaves / 10000,
+          abrirComprandoMatrices / 10000,
+          abrirComprandoAmbos / 10000
+        ],
+        backgroundColor: [
+          'rgba(255,99,132,0.6)',
+          'rgba(75,192,192,0.6)',
+          'rgba(255,206,86,0.6)',
+          'rgba(153,102,255,0.6)'
+        ]
+      }]
+    },
+    options: {
+      responsive: true,
+      plugins: { legend: { display: false } },
+      scales: {
+        y: {
+          beginAtZero: true,
+          title: { display: true, text: 'Oro' }
+        }
+      }
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- update 'Abrir vs Vender' chart with four bars
  - Vender stack de encriptación
  - Abrir con llaves
  - Abrir comprando matrices
  - Abrir comprando matrices y encriptaciones

## Testing
- `node -e "require('./js/fractales-gold-ui.js');"`

------
https://chatgpt.com/codex/tasks/task_e_686d89c672bc8328ba997db08b3304d8