### PR TITLE
Support custom price text for legend crafting

### DIFF
--- a/css/leg-css.css
+++ b/css/leg-css.css
@@ -352,6 +352,14 @@ select {
   padding: 4px 8px;
 }
 
+.item-price-container.custom-text {
+  opacity: 0.9;
+  color: #a0aec0;
+  font-style: italic;
+  padding: 4px 8px;
+  text-align: right;
+}
+
 .item-price-container .price-row {
   display: flex;
   align-items: center;

--- a/js/legendaryCrafting1gen.js
+++ b/js/legendaryCrafting1gen.js
@@ -24,12 +24,21 @@ const quickLoadButtons = {
   btnFrenesi: { id: 'btnFrenesi', itemId: '30697', itemName: 'Frenesí' }
 };
 
+// Mensajes personalizados para ítems sin precio en el mercado
+const customPriceTexts = [
+  { name: 'Don de la exploración', display: 'Recompensa por completar mapas', keywords: ['exploraci'] },
+  { name: 'Don de la batalla', display: 'Se compra con Memorias de batalla', keywords: ['batalla'] },
+  { name: 'Esquirla de hematites', display: 'Intercambio en Páramos Argentos', keywords: ['hematites'] },
+  { name: 'Esquirla de obsidiana', display: 'Compra con karma/laureles', keywords: ['obsidiana'] }
+];
+
 window.appFirstGen = new LegendaryCraftingBase({
   getItemById: id => getLegendaryItem(parseInt(id)),
   items: Object.values(LEGENDARY_ITEMS),
   createIngredientTree,
   isBasicMaterial,
   quickLoadButtons,
+  customPriceTexts,
   elementIds: {
     craftingTree: 'craftingTree',
     summary: 'summary',

--- a/js/legendaryCrafting3gen.js
+++ b/js/legendaryCrafting3gen.js
@@ -21,12 +21,20 @@ const quickLoadButtons = {
   btnReflexion: { id: 'btnReflexion', itemId: '96652', itemName: 'Reflexión de Aurene' }
 };
 
+const customPriceTexts = [
+  { name: 'Don de la exploración', display: 'Recompensa por completar mapas', keywords: ['exploraci'] },
+  { name: 'Don de la batalla', display: 'Se compra con Memorias de batalla', keywords: ['batalla'] },
+  { name: 'Esquirla de hematites', display: 'Intercambio en Páramos Argentos', keywords: ['hematites'] },
+  { name: 'Esquirla de obsidiana', display: 'Compra con karma/laureles', keywords: ['obsidiana'] }
+];
+
 window.appThirdGen = new LegendaryCraftingBase({
   getItemById: id => getLegendary3GenItem(parseInt(id)),
   items: Object.values(LEGENDARY_ITEMS_3GEN),
   createIngredientTree,
   isBasicMaterial: isBasic3GenMaterial,
   quickLoadButtons,
+  customPriceTexts,
   elementIds: {
     craftingTree: 'craftingTreeThird',
     summary: 'summaryThird',


### PR DESCRIPTION
## Summary
- add configurable `customPriceTexts` option to `LegendaryCraftingBase`
- show custom message instead of gold values when ingredient names match
- hook new feature into first and third gen crafting modules
- style custom message in CSS

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_686dcee3a35c8328b8b4541c50a2c602