### PR TITLE
Fix debug logging syntax in Ingredient3gen

### DIFF
--- a/js/utils/Ingredient3gen.js
+++ b/js/utils/Ingredient3gen.js
@@ -138,6 +138,7 @@ export class Ingredient {
     
     // Depuración para Vial de sangre espesa
     if (this.id === 24293) {
+      console.debug('[DEBUG][setPrices]', {
         buyPrice: this._buyPrice,
         sellPrice: this._sellPrice,
         _priceLoaded: this._priceLoaded
@@ -152,6 +153,7 @@ export class Ingredient {
   isPriceLoaded() {
     // Depuración para Vial de sangre espesa
     if (this.id === 24293) {
+      console.debug('[DEBUG][isPriceLoaded]', {
         _priceLoaded: this._priceLoaded,
         _buyPrice: this._buyPrice,
         _sellPrice: this._sellPrice,


### PR DESCRIPTION
## Summary
- fix missing `console.debug` call for Vial de sangre espesa debug output

## Testing
- `node --check js/utils/Ingredient3gen.js`

------
https://chatgpt.com/codex/tasks/task_e_686dd45a6e288328a15f815e46d53523