### PR TITLE
Fix total crafted computation

### DIFF
--- a/js/item.js
+++ b/js/item.js
@@ -846,7 +846,12 @@ const precioVentaUnidadMercado = (mainNode && typeof mainNode.sell_price === 'nu
     for (const ing of ingredientObjs) {
       totalBuy += ing.total_buy || 0;
       totalSell += ing.total_sell || 0;
-      totalCrafted += ing.total_crafted || 0;
+      // Si el ingrediente no es crafteable, usar el costo de compra
+      const craftedVal =
+        (ing.total_crafted !== undefined && ing.total_crafted !== null)
+          ? ing.total_crafted
+          : ing.total_buy || 0;
+      totalCrafted += craftedVal;
     }
     return { totalBuy, totalSell, totalCrafted };
   }


### PR DESCRIPTION
## Summary
- show buy cost for non-craftable ingredients when summing crafted totals

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686de9fa82dc83288265982b9f5e17e8