### PR TITLE
Add visible loaders for tribute tabs

### DIFF
--- a/dones.html
+++ b/dones.html
@@ -43,9 +43,8 @@
       </div>
     </div>
     <main>
-      <div id="tributo-content">
-        <div id="loader-tributo" class="loader" style="display:none;"></div>
-      </div>
+      <div id="loader-tributo" class="loader" style="display:none;"></div>
+      <div id="tributo-content"></div>
     </main>
   </div>
 
@@ -58,9 +57,8 @@
       </div>
     </div>
     <main>
-      <div id="tributo-draconico-content">
-        <div id="loader-tributo-draconico" class="loader" style="display:none;"></div>
-      </div>
+      <div id="loader-tributo-draconico" class="loader" style="display:none;"></div>
+      <div id="tributo-draconico-content"></div>
     </main>
   </div>
 


### PR DESCRIPTION
## Summary
- ensure loaders in "Tributo Místico" and "Tributo Dracónico" tabs remain visible while data loads

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest -q`
- `cargo test` *(fails: no Cargo.toml)*
- `go test ./...` *(fails: no Go module)*

------
https://chatgpt.com/codex/tasks/task_e_686f4092eb408328bdf70bc8543846b1