### PR TITLE
Add item icons to fractal gold tables

### DIFF
--- a/css/global-gw.css
+++ b/css/global-gw.css
@@ -2357,3 +2357,12 @@ p .info-text{
 .toast-info {
   background: #2196F3;
 }
+
+/* Iconos de ítems reutilizables */
+.item-icon {
+  width: 24px;
+  height: 24px;
+  margin-right: 6px;
+  vertical-align: middle;
+  object-fit: contain;
+}

--- a/fractales-gold.html
+++ b/fractales-gold.html
@@ -90,7 +90,7 @@
     });
   </script>
   <script type="module">
-    import { renderGraficoContribuciones, renderGraficoAbrirVsVender, renderTablaPrecios, renderTablaPromedios, renderTablaResumenOro, renderTablaReferenciasProfit, fetchItemPrices } from './js/fractales-gold-ui.js';
+    import { renderGraficoContribuciones, renderGraficoAbrirVsVender, renderTablaPrecios, renderTablaPromedios, renderTablaResumenOro, renderTablaReferenciasProfit, fetchItemPrices, fetchIconsFor, ICON_ID_MAP } from './js/fractales-gold-ui.js';
 
     async function fetchPreciosFractales() {
       const priceMap = await fetchItemPrices([75919, 73248]);
@@ -105,6 +105,7 @@
 
     async function renderTodo() {
       const preciosFractales = await fetchPreciosFractales();
+      await fetchIconsFor(Object.values(ICON_ID_MAP));
       await renderTablaPromedios();
       await renderTablaPrecios();
       const resumenData = await renderTablaResumenOro('tabla-resumen-oro', preciosFractales);


### PR DESCRIPTION
## Summary
- add generic item icon style
- support fetching item icons in fractal gold UI
- prepend icons in Promedios and Precios tables
- add icons in Referencias de profit

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6870698e388c8328b7874a59eeed9b96